### PR TITLE
Add exponential sampling method

### DIFF
--- a/include/fit-KSpipi-time-dependent.inl
+++ b/include/fit-KSpipi-time-dependent.inl
@@ -265,8 +265,8 @@ int main(int argc, char** argv)
 		//plotterWithTime.FillHistograms(data, model_dz_fitted, outfilename, args.plotnbins); 
 		plotterWithTime.FillDataHistogram(data, args.plotnbins);
 		plotterWithTime.FillModelHistogram(model_dz_fitted,
-										   MinuitTools::GetParameterPointer(fitted_parameters, "y")->GetValue(), 
 										   MinuitTools::GetParameterPointer(fitted_parameters, "tau")->GetValue(),
+										   MinuitTools::GetParameterPointer(fitted_parameters, "y")->GetValue(), 
 										   args.plotnbins);
 		if (outfilename != "") plotterWithTime.SaveHistograms(outfilename);
 		plotterWithTime.SetCustomAxesTitles("#it{m}^{2}_{+} [GeV^{2}/#it{c}^{4}]","#it{m}^{2}_{#minus} [GeV^{2}/#it{c}^{4}]","#it{m}^{2}_{#it{#pi#pi}} [GeV^{2}/#it{c}^{4}]");

--- a/include/generate-KSpipi-time-dependent.inl
+++ b/include/generate-KSpipi-time-dependent.inl
@@ -124,10 +124,10 @@ int main( int argc, char** argv  )
 	auto start = std::chrono::high_resolution_clock::now();	
 
 	// auto data_dz = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_dz,args.nevents,args.seed);
-	auto data_dz = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_dz,args.nevents,args.seed  ,y(),1./tau());
+	auto data_dz = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_dz, tau(), y(), args.nevents, args.seed);
 	std::cout << "Generated " << data_dz.size() << " D0 candidates." << std::endl;
 	// auto data_db = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_db,args.nevents,args.seed+1);
-	auto data_db = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_db,args.nevents,args.seed+1,y(),1./tau());
+	auto data_db = phsp.GenerateDataWithTime<MSqPlus,MSqMinus,MSqZero,DecayTime>(model_db, tau(), y(), args.nevents, args.seed+1);
 	std::cout << "Generated " << data_db.size() << " D0bar candidates." << std::endl;
 
 
@@ -203,7 +203,7 @@ int main( int argc, char** argv  )
 		std::string outfilename = args.outdir + outprefix + "-HIST.root";
 		//plotterWithTime.FillHistograms(data, model_dz, outfilename, args.plotnbins); 
 		plotterWithTime.FillDataHistogram(data, args.plotnbins);
-		plotterWithTime.FillModelHistogram(model_dz, y(), 1./tau(), args.plotnbins); 
+		plotterWithTime.FillModelHistogram(model_dz, tau(), y(), args.plotnbins); 
 		// plotterWithTime.FillModelHistogram(model_dz, y(), 1./tau()); 
 		if (outfilename != "") plotterWithTime.SaveHistograms(outfilename);
 		plotterWithTime.SetCustomAxesTitles("#it{m}^{2}_{+} [GeV^{2}/#it{c}^{4}]","#it{m}^{2}_{#minus} [GeV^{2}/#it{c}^{4}]","#it{m}^{2}_{#it{#pi#pi}} [GeV^{2}/#it{c}^{4}]");

--- a/include/physics/ThreeBodyPhaseSpace.h
+++ b/include/physics/ThreeBodyPhaseSpace.h
@@ -510,7 +510,7 @@ public:
 				MSq12 m0 = (a+b).mass2();
 				MSq13 m1 = (a+c).mass2();
 				double weight = phsp_weight(a,b,c) * model(hydra::tie(m0,m1,t));
-				if (y!=-999 && Gamma!=-999) return weight * 1. / ((1.-abs(y))*Gamma * exp(-(1-abs(y))*Gamma*t)); // weight under exponential outline
+				if (y!=-999 && Gamma!=-999) return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
 				return weight;
 			});
 
@@ -593,7 +593,7 @@ public:
 			MSq12 m0 = (a+b).mass2();
 			MSq13 m1 = (a+c).mass2();
 			double weight = phsp_weight(a,b,c) * model(hydra::tie(m0,m1,t));
-			if (y!=-999 && Gamma!=-999) return weight * 1. / ((1.-abs(y))*Gamma * exp(-(1-abs(y))*Gamma*t)); // weight under exponential outline
+			if (y!=-999 && Gamma!=-999) return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
 			return weight;
 		});
 

--- a/include/physics/ThreeBodyPhaseSpace.h
+++ b/include/physics/ThreeBodyPhaseSpace.h
@@ -436,8 +436,11 @@ public:
 
 	template<typename MSq12, typename MSq13, typename MSq23, typename Time, typename Model>
 	__hydra_dual__ inline
-	auto GenerateDataWithTime(Model &model, size_t nevents, size_t rndseed=0, double y=-999, double Gamma=-999)
+	auto GenerateDataWithTime(Model &model, double tau, double y, size_t nevents, size_t rndseed=0)
 	{
+		// convert tau to Gamma
+		double Gamma = 1. / tau;
+
 		// Output container
 		hydra::multivector<hydra::tuple<MSq12,MSq13,MSq23,Time>, hydra::device::sys_t> data;
 
@@ -510,17 +513,12 @@ public:
 				MSq12 m0 = (a+b).mass2();
 				MSq13 m1 = (a+c).mass2();
 				double weight = phsp_weight(a,b,c) * model(hydra::tie(m0,m1,t));
-				if (y!=-999 && Gamma!=-999) return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
-				return weight;
+				return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
 			});
 
-			// generated decay time uniformuly when Gamma and y is not set, otherwise generate with the exp(-(1-abs(y))*Gamma*t)
-			// just like Jordi's code
-			if (!(y!=-999 && Gamma!=-999)) hydra::fill_random( time_data, uniform, seed()); 
-			else {
-				hydra::fill_random( uniform_data, uniform_for_exp_outline, seed()); // the RngFormula<Exponential> looks confusing, 
-				hydra::copy(uniform_data | exp_outline_invcdf, time_data);	    	// I would like to use the explicit invcdf lambda above
-			}
+			// generated decay time from the exp(-(1-abs(y))*Gamma*t) distribution, just like Jordi's code
+			hydra::fill_random( uniform_data, uniform_for_exp_outline, seed()); // the RngFormula<Exponential> looks confusing, 
+			hydra::copy(uniform_data | exp_outline_invcdf, time_data);	    	// I would like to use the explicit invcdf lambda above
 			
 
 			auto events_with_time = phsp_events.Meld( time_data );
@@ -543,8 +541,11 @@ public:
 
 	template<typename MSq12, typename MSq13, typename MSq23, typename Time, typename Model>
 	__hydra_dual__ inline
-	auto GenerateSparseHistogramWithTime(Model &model, size_t nevents, size_t nbins=300, double y=-999, double Gamma=-999, size_t rndseed=0)
+	auto GenerateSparseHistogramWithTime(Model &model, double tau, double y, size_t nevents, size_t nbins=300, size_t rndseed=0)
 	{
+		// convert tau to Gamma
+		double Gamma = 1. / tau;
+
 		// Functor to compute Dalitz variables from 4-momenta
 		auto dalitz_calculator = hydra::wrap_lambda( [] __hydra_dual__ (hydra::Vector4R a, hydra::Vector4R b, hydra::Vector4R c, Time t)
 		{
@@ -575,12 +576,9 @@ public:
 		});
 
 
+		hydra::fill_random( uniform_data, uniform_for_exp_outline, seed());
+		hydra::copy(uniform_data | exp_outline_invcdf, time_data);
 
-		if (!(y!=-999 && Gamma!=-999)) hydra::fill_random( time_data, uniform, seed()); 
-		else {
-			hydra::fill_random( uniform_data, uniform_for_exp_outline, seed());
-			hydra::copy(uniform_data | exp_outline_invcdf, time_data);
-		}
 
 		auto events = phsp_events.Meld( time_data );
 
@@ -593,8 +591,7 @@ public:
 			MSq12 m0 = (a+b).mass2();
 			MSq13 m1 = (a+c).mass2();
 			double weight = phsp_weight(a,b,c) * model(hydra::tie(m0,m1,t));
-			if (y!=-999 && Gamma!=-999) return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
-			return weight;
+			return weight * 1. / exp(-(1-abs(y))*Gamma*t); // weight under exponential outline
 		});
 
 		// Compute Dalitz variables and weights

--- a/include/tools/DalitzPlotterWithTime.h
+++ b/include/tools/DalitzPlotterWithTime.h
@@ -8,9 +8,9 @@ private:
 
 	// Fill amplitude histogram
 	template<typename Model>
-	THnSparseD *fill_histogram(Model const &model, size_t n, size_t nbins=200,  double y=-999, double Gamma=-999)
+	THnSparseD *fill_histogram(Model const &model, double tau, double y, size_t n, size_t nbins=200)
 	{
-		auto histo = _phsp.GenerateSparseHistogramWithTime<MSq12, MSq13, MSq23, Time>(model, n, nbins, y, Gamma);
+		auto histo = _phsp.GenerateSparseHistogramWithTime<MSq12, MSq13, MSq23, Time>(model, tau, y, n, nbins);
 
 		auto h = _phsp.RootHistogramWithTime(_labels[0].c_str(), _labels[1].c_str(), _labels[2].c_str(), nbins);
 		fill_root_histogram(h,histo);
@@ -50,17 +50,17 @@ public:
 	}
 
 	template<typename T>
-	THnSparseD* FillModelHistogram(T & model, double y=-999, double Gamma=-999, const size_t nbins=200, Int_t lineColor=kRed, Int_t lineStyle=kSolid)
+	THnSparseD* FillModelHistogram(T & model, double tau, double y, const size_t nbins=200, Int_t lineColor=kRed, Int_t lineStyle=kSolid)
 	{
 		std::cout << "Filling histogram for model..." << std::flush;
 
 		if (!_h_data) {
 			std::cout << "WARNING: data histograms has not been filled, the model histogram cannot be correctly normalized." << std::endl;
-			_h_model = fill_histogram(model,5000000, nbins, y, Gamma);
+			_h_model = fill_histogram(model, tau, y, 5000000, nbins);
 		} else {
 			double ndata = get_integral(_h_data);
 			double nevents = (ndata<5e5) ? 10*5e5 : 10*ndata;
-			_h_model = fill_histogram(model, nevents, nbins, y, Gamma);
+			_h_model = fill_histogram(model, tau, y, nevents, nbins);
 			_h_model->Scale( ndata/get_integral(_h_model) );
 		}
 


### PR DESCRIPTION
Add exponential sampling method to the time dependent mode without time resolution.

The comparison between generated toy data (black dot) and model used for generation (red histogram):
![image](https://user-images.githubusercontent.com/9352604/109663085-ad775a80-7ba6-11eb-82cc-7732a7823013.png)
![image](https://user-images.githubusercontent.com/9352604/109663138-be27d080-7ba6-11eb-9b53-f10856f247ca.png)



   The result of fit to 2M sample generated with tau=0.4101, x=0.004, y=0.006:
   ``` 
      0   ||       tau ||  free   ||     0.4098736660807 ||0.0002905023407202
      1   ||         x || limited ||   0.004697288753164 ||0.0007577243726046
      2   ||         y || limited ||   0.005483016205555 ||0.0006657726219753
   ```

The comparison between toy data (black dot) and fit result (red histogram):
![image](https://user-images.githubusercontent.com/9352604/109663910-94bb7480-7ba7-11eb-80f2-ec8b3b0caaa7.png)
![image](https://user-images.githubusercontent.com/9352604/109663961-a1d86380-7ba7-11eb-9a22-f4abca0e8e82.png)
